### PR TITLE
Update disconnect.js

### DIFF
--- a/lib/disconnect.js
+++ b/lib/disconnect.js
@@ -17,7 +17,10 @@ Disconnect.create = function (client, orderName, numbers, callback){
       name: orderName,
       _nameXmlElement: "name",
       disconnectTelephoneNumberOrderType: {
-        telephoneNumber: numbers
+        telephoneNumberList:
+          numbers.map(function(number) {
+            return {telephoneNumber: number};
+          })
       }
     }
   };


### PR DESCRIPTION
updated disconnect.js to correctly handle list of numbers. still can only disconnect one number at a time because xml2js it converting json list to list of xml parents that is not recognized by api.network.  see issue at https://github.com/bandwidthcom/node-bandwidth-iris/issues/3#issuecomment-164462599
