### PR TITLE
Return response along with error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -226,6 +226,8 @@ Client.prototype.checkResponse = function(res, callback){
       if(err){
         return callback(err);
       }
+      var keys = Object.keys(r);
+      var result = (keys.length == 1) ? r[keys[0]] : r;
       var code = findFirstDescendant(r, "errorCode");
       var description = findFirstDescendant(r, "description");
       if(!code){
@@ -243,15 +245,14 @@ Client.prototype.checkResponse = function(res, callback){
           else{
             return callback(new errors.BandwidthMultipleError(errs.map(function(e){
               return new errors.BandwidthError(e.code, e.description, res.statusCode);
-            })));
+            })), result);
           }
         }
       }
       if(code && description && code !== "0"){
-        return callback(new errors.BandwidthError(code, description, res.statusCode));
+        return callback(new errors.BandwidthError(code, description, res.statusCode), result);
       }
-      var keys = Object.keys(r);
-      defaultHandler((keys.length == 1)?r[keys[0]]:r);
+      defaultHandler(result);
     });
   }
   else{

--- a/lib/order.js
+++ b/lib/order.js
@@ -29,7 +29,7 @@ Order.get = function(client, id, callback){
   };
  client.makeRequest("get", client.concatAccountPath(ORDER_PATH) + "/" + id, function(err, item){
   if(err){
-    return callback(err);
+    return callback(err, item);
   }
   item.order.client = client;
   item.order.__proto__ = Order.prototype;

--- a/lib/order.js
+++ b/lib/order.js
@@ -13,7 +13,7 @@ Order.create = function(client, item, callback){
   };
  client.makeRequest("post", client.concatAccountPath(ORDER_PATH), {order: item}, function(err, item){
   if(err){
-    return callback(err);
+    return callback(err, item);
   }
   item.order.client = client;
   item.order.__proto__ = Order.prototype;

--- a/lib/site.js
+++ b/lib/site.js
@@ -84,12 +84,11 @@ Site.prototype.getSipPeers = function(callback){
     if(err){
       return callback(err);
     }
-    var items = res.sipPeers;
+    var items = res.sipPeers.sipPeer;
     if(!Array.isArray(items)){
       items = [items];
     }
-    callback(null, items.map(function(i){
-      var item = i.sipPeer;
+    callback(null, items.map(function(item){
       item.client = client;
       item.__proto__ = SipPeer.prototype;
       item.id = item.peerId;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandwidth-iris",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "NodeJs Client library for IRIS / BBS API",
   "main": "index.js",
   "scripts": {

--- a/test/client.js
+++ b/test/client.js
@@ -244,6 +244,77 @@ describe("client tests", function(){
         param3: true
       }, done);
     });
+
+    it("should callback with err and result", function(done){
+      var responseXml = [
+        '<?xml version="1.0"?>',
+        '<OrderResponse>',
+          '<CompletedQuantity>1</CompletedQuantity>',
+          '<CreatedByUser>xyz</CreatedByUser>',
+          '<ErrorList>',
+            '<Error>',
+              '<Code>5005</Code>',
+              '<Description>The telephone number is unavailable for ordering</Description>',
+              '<TelephoneNumber>6365555555</TelephoneNumber>',
+          ' </Error>',
+        ' </ErrorList>',
+          '<FailedNumbers>',
+            '<FullNumber>6365555555</FullNumber>',
+          '</FailedNumbers>',
+          '<LastModifiedDate>2018-03-01T16:39:55.335Z</LastModifiedDate>',
+          '<OrderCompleteDate>2018-03-01T16:39:55.335Z</OrderCompleteDate>',
+          '<Order>',
+          ' <Name>NEC Main Test:215</Name>',
+            '<OrderCreateDate>2018-03-01T16:39:55.255Z</OrderCreateDate>',
+            '<PeerId>510464</PeerId>',
+            '<BackOrderRequested>false</BackOrderRequested>',
+          ' <ExistingTelephoneNumberOrderType>',
+              '<TelephoneNumberList>',
+                '<TelephoneNumber>6365555555</TelephoneNumber>',
+                '<TelephoneNumber>6361231234</TelephoneNumber>',
+              '</TelephoneNumberList>',
+            '</ExistingTelephoneNumberOrderType>',
+            '<PartialAllowed>true</PartialAllowed>',
+            '<SiteId>90210</SiteId>',
+          '</Order>',
+          '<OrderStatus>PARTIAL</OrderStatus>',
+          '<CompletedNumbers>',
+            '<TelephoneNumber>',
+              '<FullNumber>6361231234</FullNumber>',
+            '</TelephoneNumber>',
+          '</CompletedNumbers>',
+          '<Summary>1 out of 2 numbers ordered in (636)</Summary>',
+          '<FailedQuantity>1</FailedQuantity>',
+        '</OrderResponse>'
+      ].join('');
+  
+      var span = nock("https://api.inetwork.com").get("/v1.0/test?param1=1&param2=test&param3=true")
+        .reply(200, responseXml, {"Content-Type": "application/xml"})
+      client.makeRequest("get", "/test", {
+        param1: 1,
+        param2: "test",
+        param3: true
+      }, function(err, result){
+        if(!err){
+          return done(new Error("Error has been expected"));
+        }
+        try {
+          err.message.should.equal("The telephone number is unavailable for ordering");
+          err.code.should.equal(5005);
+  
+          if (!result) {
+            return done(new Error("Expected result to not be undefined"))
+          }
+  
+          result.failedQuantity.should.equal(1);
+          result.completedNumbers.telephoneNumber.fullNumber.should.equal('6361231234');
+          done();
+        } catch (fail) {
+          done(fail);
+        }
+
+      });
+    })
   });
   describe("#concatAccountPath", function(){
     it("should return formatted url", function(){

--- a/test/order.js
+++ b/test/order.js
@@ -135,6 +135,66 @@ describe("Order", function(){
         done(new Error("An error is expected"));
       });
     });
+    it("should return error along with item on partial failure", function(done){
+      var responseXml = [
+        '<?xml version="1.0"?>',
+        '<OrderResponse>',
+          '<CompletedQuantity>1</CompletedQuantity>',
+          '<CreatedByUser>xyz</CreatedByUser>',
+          '<ErrorList>',
+            '<Error>',
+              '<Code>5005</Code>',
+              '<Description>The telephone number is unavailable for ordering</Description>',
+              '<TelephoneNumber>6365555555</TelephoneNumber>',
+          ' </Error>',
+        ' </ErrorList>',
+          '<FailedNumbers>',
+            '<FullNumber>6365555555</FullNumber>',
+          '</FailedNumbers>',
+          '<LastModifiedDate>2018-03-01T16:39:55.335Z</LastModifiedDate>',
+          '<OrderCompleteDate>2018-03-01T16:39:55.335Z</OrderCompleteDate>',
+          '<Order>',
+          ' <Name>NEC Main Test:215</Name>',
+            '<OrderCreateDate>2018-03-01T16:39:55.255Z</OrderCreateDate>',
+            '<PeerId>510464</PeerId>',
+            '<BackOrderRequested>false</BackOrderRequested>',
+          ' <ExistingTelephoneNumberOrderType>',
+              '<TelephoneNumberList>',
+                '<TelephoneNumber>6365555555</TelephoneNumber>',
+                '<TelephoneNumber>6361231234</TelephoneNumber>',
+              '</TelephoneNumberList>',
+            '</ExistingTelephoneNumberOrderType>',
+            '<PartialAllowed>true</PartialAllowed>',
+            '<SiteId>90210</SiteId>',
+          '</Order>',
+          '<OrderStatus>PARTIAL</OrderStatus>',
+          '<CompletedNumbers>',
+            '<TelephoneNumber>',
+              '<FullNumber>6361231234</FullNumber>',
+            '</TelephoneNumber>',
+          '</CompletedNumbers>',
+          '<Summary>1 out of 2 numbers ordered in (636)</Summary>',
+          '<FailedQuantity>1</FailedQuantity>',
+        '</OrderResponse>'
+      ].join('');
+      helper.nock().get("/v1.0/accounts/FakeAccountId/orders/101").reply(200, responseXml);
+      Order.get(helper.createClient(), "101", function(err, item){
+        if(!err){
+          return done(new Error("An error is expected"));
+        }
+        if(!item){
+          return done(new Error("An item was expected as well"));
+        }
+        
+        try {
+          item.failedQuantity.should.equal(1);
+          item.completedNumbers.telephoneNumber.fullNumber.should.equal('6361231234');
+          done();
+        } catch (fail) {
+          done(fail);
+        }
+      });
+    });
   });
   describe("#update", function(){
     it("should update a order", function(done){


### PR DESCRIPTION
Client.checkResponse should callback with the result even if it detects
an error. For example, in the case of ordering multiple phone numbers
and we get a partial failure, only the error is sent in the callback,
not the information about which ones were successful.

Fixes Bandwidth/node-bandwidth-iris#22